### PR TITLE
Fixed issue with AmazonS3 settings

### DIFF
--- a/config/config-heroku-template.json
+++ b/config/config-heroku-template.json
@@ -72,7 +72,7 @@
     },
     "FileSettings": {
         "MaxFileSize": 52428800,
-        "DriverName": "local",
+        "DriverName": "${FILE_SETTINGS__DRIVER_NAME}",
         "Directory": "./data/",
         "EnablePublicLink": false,
         "PublicLinkSalt": "A705AklYF8MFDOfcwh3I488G8vtLlVip",


### PR DESCRIPTION
The FILE_SETTINGS__DRIVER_NAME was not used in config-heroku-template.json. Due to this, the AmazonS3 settings made in environmental settings in heroku was not taking effect. This patch fixes the issue.