### PR TITLE
Fix config arg for v3.6.0

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
     "MATTERMOST_DOWNLOAD_URI": {
         "description": "The URI to the compiled Mattermost binary you would like to run. Defaults to latest release. See https://www.mattermost.org/download/ for download links.",
         "required": true,
-        "value": "https://releases.mattermost.com/3.3.0/mattermost-enterprise-3.3.0-linux-amd64.tar.gz"
+        "value": "https://releases.mattermost.com/3.6.0/mattermost-enterprise-3.6.0-linux-amd64.tar.gz"
     },
     "FILE_SETTINGS__DRIVER_NAME": {
         "description": "The type of file storage to use. Must be local or amazons3. WARNING: If local, files will be periodically wiped when the dyno restarts. Only use local for temporary preview instances.",

--- a/run.sh
+++ b/run.sh
@@ -6,4 +6,4 @@ export FILE_SETTINGS__AMAZON_S3_BUCKET=${FILE_SETTINGS__AMAZON_S3_BUCKET:=""}
 
 lib/envsubst < config/config-heroku-template.json > config/config-heroku.json
 
-bin/platform -config=config/config-heroku.json
+bin/platform --config=config/config-heroku.json


### PR DESCRIPTION
Since v3.6.0, the argument to specify a config file has become `--config`.