### PR TITLE
Make ExperimentalDefaultChannels an array

### DIFF
--- a/config/config-heroku-template.json
+++ b/config/config-heroku-template.json
@@ -108,7 +108,7 @@
         "ExperimentalHideTownSquareinLHS": false,
         "ExperimentalTownSquareIsReadOnly": false,
         "ExperimentalPrimaryTeam": "",
-        "ExperimentalDefaultChannels": ""
+        "ExperimentalDefaultChannels": []
     },
     "DisplaySettings": {
         "CustomUrlSchemes": [],


### PR DESCRIPTION
#### Summary

The server would die on startup because it couldnt deserialize `TeamSettings.ExperimentalDefaultChannels` to `[]string`. 

This modifies the setting to be of type array by default.

